### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,5 @@
 exclude:
   global:
     - vendor/**
+    - test/**
+    - "**/*_test.go"


### PR DESCRIPTION
Ignore these two snyk errors. One is a hardcoded secret used in a unit test and nowhere else (it's not a real secret), the other is a complaint about the e2eprovider removing an existing socket before it creates a socket at that same path. Nothing in the core driver that runs on real clusters.

```
 ✗ [Low] Hardcoded Secret
   ID: cf46edb3-d35f-4887-855d-6ba6d11abeee 
   Path: pkg/util/secretutil/secret_test.go, line 104 
   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in keyPEM.
 ✗ [Low] Path Traversal
   ID: 9ad47a1a-2143-4d4f-b0fb-88ea459987f9 
   Path: test/e2eprovider/e2e_provider.go, line 54 
   Info: Unsanitized input from a CLI argument flows into os.Remove, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to delete arbitrary files.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-secrets-store-csi-driver-main-security/1745954190951190528

/cc @openshift/storage
