### PR TITLE
NO-JIRA: Add Dockerfile.bats for test image

### DIFF
--- a/Dockerfile.bats
+++ b/Dockerfile.bats
@@ -1,0 +1,9 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
+COPY . .
+RUN make bats && bats-core-*/install.sh bats
+
+# "src" is built by a prow job when building final images.
+# It contains full repository sources + jq + pyhon with yaml module.
+FROM src
+COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/bats /usr/local


### PR DESCRIPTION
Required by https://github.com/openshift/release/pull/51365

I tried a simple `FROM src` image in https://github.com/openshift/release/pull/51367 but it still failed with `make: bats: No such file or directory`. So we need to use the builder image to `make bats` and then copy that into the src image.

/cc @openshift/storage @ropatil010
