### PR TITLE
NO-JIRA: Dockerfile.bats should build helm and kubectl

### DIFF
--- a/Dockerfile.bats
+++ b/Dockerfile.bats
@@ -1,9 +1,11 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
-RUN make bats && bats-core-*/install.sh bats
+RUN make bats helm kubectl && bats-core-*/install.sh bats
 
 # "src" is built by a prow job when building final images.
 # It contains full repository sources + jq + pyhon with yaml module.
 FROM src
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/bats /usr/local
+COPY --from=builder /usr/local/bin/helm /usr/local/bin
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -27,6 +27,10 @@ export ANNOTATION_VALUE=${ANNOTATION_VALUE:-"app=test"}
         --set "injector.enabled=false" \
         --set "csi.enabled=true" \
         --set "global.openshift=true" \
+        --set "injector.agentImage.repository=docker.io/hashicorp/vault" \
+        --set "server.image.repository=docker.io/hashicorp/vault" \
+        --set "csi.image.repository=docker.io/hashicorp/vault-csi-provider" \
+        --set "csi.agent.image.repository=docker.io/hashicorp/vault" \
         --set "csi.daemonSet.providersDir=/var/run/secrets-store-csi-providers"
   oc patch daemonset -n vault vault-csi-provider --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/securityContext", "value": {"privileged": true} }]'
   sleep 10 


### PR DESCRIPTION
Follow up to https://github.com/openshift/secrets-store-csi-driver/pull/17

This should eliminate some of the hacks we were testing in https://github.com/openshift/release/pull/51365#discussion_r1582736008 -- by building kubectl and helm in the Dockerfile.bats image and setting the `helm install` arguments so that it pulls the vault images from docker instead of the redhat registry.

Tested on a 4.16 cluster from the `default` namespace with these changes:

```
[root@d6db10890072 secrets-store-csi-driver]# make e2e-vault
make: go: No such file or directory
make: go: No such file or directory
make: go: No such file or directory
make: go: No such file or directory
make: git: No such file or directory
bats -t test/bats/vault.bats
1..17
ok 1 install vault provider
ok 2 setup vault
ok 3 deploy vault secretproviderclass crd
ok 4 CSI inline volume test with pod portability
ok 5 CSI inline volume test with pod portability - read vault secret from pod
ok 6 CSI inline volume test with pod portability - rotation succeeds
ok 7 CSI inline volume test with pod portability - unmount succeeds
ok 8 Sync with K8s secrets - create deployment
ok 9 Sync with K8s secrets - read secret from pod, read K8s secret, read env var, check secret ownerReferences with multiple owners
ok 10 Sync with K8s secrets - delete deployment, check secret is deleted
ok 11 Test Namespaced scope SecretProviderClass - create deployment
ok 12 Test Namespaced scope SecretProviderClass - Sync with K8s secrets - read secret from pod, read K8s secret, read env var, check secret ownerReferences
ok 13 Test Namespaced scope SecretProviderClass - Sync with K8s secrets - delete deployment, check secret deleted
ok 14 Test Namespaced scope SecretProviderClass - Should fail when no secret provider class in same namespace
ok 15 deploy multiple vault secretproviderclass crd
ok 16 deploy pod with multiple secret provider class
ok 17 CSI inline volume test with multiple secret provider class
```

/cc @openshift/storage @ropatil010 @Phaow