### PR TITLE
NO-JIRA: Dockerfile.bats needs to install yq

### DIFF
--- a/Dockerfile.bats
+++ b/Dockerfile.bats
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
-RUN make bats helm kubectl && bats-core-*/install.sh bats
+RUN make bats helm kubectl yq && bats-core-*/install.sh bats
 
 # "src" is built by a prow job when building final images.
 # It contains full repository sources + jq + pyhon with yaml module.
@@ -9,3 +9,4 @@ FROM src
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/bats /usr/local
 COPY --from=builder /usr/local/bin/helm /usr/local/bin
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin
+COPY --from=builder /usr/local/bin/yq /usr/local/bin


### PR DESCRIPTION
This is required by https://github.com/openshift/release/pull/53638

`make e2e-deploy-manifest` uses `yq` to replace the driver image in the manifest, which means `Dockerfile.bats` needs to install `yq` for that to work.

/cc @openshift/storage
