### PR TITLE
OCPBUGS-52474: adds wait condition for deployment to have status.replicas=2

### DIFF
--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -263,6 +263,8 @@ EOF
 
   kubectl apply -n negative-test-ns -f $BATS_TESTS_DIR/deployment-synck8s.yaml
 
+  # wait for pod to be created
+  kubectl wait --for=jsonpath='{.status.replicas}'=2 deployment -l app=busybox -n negative-test-ns --timeout=60s
   POD=$(kubectl get pod -l app=busybox -n negative-test-ns -o jsonpath="{.items[0].metadata.name}")
   cmd="kubectl describe pod $POD -n negative-test-ns | grep 'FailedMount.*failed to get secretproviderclass negative-test-ns/vault-foo-sync.*not found'"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"


### PR DESCRIPTION
Test case "Test Namespaced scope SecretProviderClass - Should fail when no secret provider class in same namespace" failing as it is not waiting for the pod to be up

The PR adds a wait condition for the deployment to have status.replicas=2 before it do a `kubectl get pod`