### PR TITLE
SSCSI-98: UPSTREAM: <carry>: Add required FIPS flags

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -2,6 +2,8 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS 
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
 RUN make build
+# Print build settings information embedded in the binary.
+RUN go version -m _output/secrets-store-csi
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/_output/secrets-store-csi /bin/secrets-store-csi

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ shellcheck: $(SHELLCHECK)
 ## --------------------------------------
 .PHONY: build
 build:
-	GOPROXY=$(GOPROXY) CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
+	GOPROXY=$(GOPROXY) CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux go build -mod=vendor -a -tags "strictfipsruntime,openssl" -ldflags $(LDFLAGS) -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
 
 .PHONY: build-e2e-provider
 build-e2e-provider:
@@ -270,7 +270,7 @@ build-e2e-provider:
 
 .PHONY: build-windows
 build-windows:
-	GOPROXY=$(GOPROXY) CGO_ENABLED=0 GOOS=windows go build -mod=vendor -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
+	GOPROXY=$(GOPROXY) CGO_ENABLED=0 GOOS=windows go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
 
 .PHONY: build-darwin
 build-darwin:


### PR DESCRIPTION
## Description:
- Enable FIPS-compliant builds via `GOEXPERIMENT=strictfipsruntime`, `CGO_ENABLED=1`, and appropriate build tags.
     - `-tags "strictfipsruntime,openssl"`
- Update Dockerfiles to print Go module build info using `go version -m`.

## CI Changes

- https://github.com/openshift/release/pull/64430

Note: Currently, we're relying on the ART golang builder to intercept the non-compliant flags forcefully. This PR is intended to make the binary FIPS compliant by default. 