### PR TITLE
SSCSI-145: UPSTREAM: <carry>: Make GCP e2e compatible with downstream

### DIFF
--- a/Dockerfile.bats
+++ b/Dockerfile.bats
@@ -10,6 +10,12 @@ RUN unzip awscliv2.zip > /dev/null 2>&1
 RUN ./aws/install
 RUN aws --version
 
+# Install gcloud cli
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+RUN tar -xf google-cloud-cli-linux-x86_64.tar.gz
+RUN ./google-cloud-sdk/install.sh
+RUN ./google-cloud-sdk/bin/gcloud version
+
 # "src" is built by a prow job when building final images.
 # It contains full repository sources + jq + pyhon with yaml module.
 FROM src
@@ -17,9 +23,16 @@ COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/bats /
 COPY --from=builder /usr/local/bin/helm /usr/local/bin
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin
 COPY --from=builder /usr/local/bin/yq /usr/local/bin
+
+# Copy aws-cli
 COPY --from=builder /usr/local/aws-cli/ /usr/local/aws-cli/
 RUN ln -s /usr/local/aws-cli/v2/current/bin/aws /usr/local/bin/aws
 RUN aws --version
+
+# Copy gcloud cli
+COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/google-cloud-sdk/ /usr/local/google-cloud-sdk/
+RUN ln -s /usr/local/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
+RUN gcloud version
 
 # Install envsubst and less
 RUN dnf install -y gettext less && dnf clean all

--- a/test/bats/gcp.bats
+++ b/test/bats/gcp.bats
@@ -8,14 +8,136 @@ SLEEP_TIME=1
 NAMESPACE=default
 PROVIDER_NAMESPACE=kube-system
 PROVIDER_YAML=https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/main/deploy/provider-gcp-plugin.yaml
+GCP_PROVIDER_YAML=provider-gcp-plugin.yaml
 BASE64_FLAGS="-w 0"
-
-export RESOURCE_NAME=${SECRET_URI}
+YQ_DAEMONSETS_BASE_PATH='select(.kind == "DaemonSet" and .metadata.name == "csi-secrets-store-provider-gcp")'
 export FILE_NAME=${FILE_NAME:-"secret"}
 
+setup_file() {
+  export SECRET_VALUE="secret-a"
+  export RANDOM_NUM=$(echo $RANDOM | md5sum | head -c 8)
+  export SECRET_ID=test-secret-$RANDOM_NUM
+  export GCP_PROJECT_ID=$(gcloud config get-value project)
+  export GCP_PROJECT_NUM=$(gcloud projects describe $(gcloud config get-value project) --format="value(projectNumber)")
+  export RESOURCE_NAME=projects/$GCP_PROJECT_ID/secrets/$SECRET_ID/versions/latest
+  export GCP_WORKLOAD_IDENTITY_POOL=wif-pool-$RANDOM_NUM
+  export GCP_WORKLOAD_IDENTITY_PROVIDER=$GCP_WORKLOAD_IDENTITY_POOL-oidc
+  export LOCATION="global"
+  export WI_POOL_PATH=projects/$GCP_PROJECT_NUM/locations/$LOCATION/workloadIdentityPools/$GCP_WORKLOAD_IDENTITY_POOL
+
+  # Retrieve the OIDC (OpenID Connect) issuer URL from the Kubernetes API server's well-known configuration.
+  # This URL is essential for configuring an external identity provider in this case GCP Workload Identity.
+  OIDC_ISSUER=$(kubectl get --raw /.well-known/openid-configuration | jq -r .issuer )
+
+  # Retrieve the JSON Web Key Set (JWKS) from the Kubernetes API server.
+  # This JWKS contains the public keys that external identity providers use to verify
+  # the authenticity of tokens issued by the Kubernetes API server.
+  kubectl get --raw /openid/v1/jwks > cluster-jwks.json
+
+  # Create a GCP Workload Identity Pool.
+  # It enables external identities (like Kubernetes service accounts) to authenticate with Google Cloud.
+  gcloud iam workload-identity-pools create $GCP_WORKLOAD_IDENTITY_POOL \
+      --location="$LOCATION" \
+      --description="$GCP_WORKLOAD_IDENTITY_POOL" \
+      --display-name="$GCP_WORKLOAD_IDENTITY_POOL"
+
+  # Create an OIDC Workload Identity Provider within the previously created pool.
+  # This provider acts as a bridge, allowing identities from Kubernetes cluster (issued by its OIDC issuer)
+  # to be trusted by Google Cloud.
+  # --attribute-mapping="google.subject=assertion.sub": Maps the 'sub' (subject) claim from the
+  #    OIDC token (which identifies the Kubernetes service account) to the Google Cloud subject.
+  gcloud iam workload-identity-pools providers create-oidc $GCP_WORKLOAD_IDENTITY_PROVIDER \
+      --location="$LOCATION" \
+      --workload-identity-pool=$GCP_WORKLOAD_IDENTITY_POOL \
+      --issuer-uri=$OIDC_ISSUER \
+      --attribute-mapping="google.subject=assertion.sub" \
+      --jwk-json-path="cluster-jwks.json"
+
+
+  # Generate a credential configuration file for the Workload Identity Provider.
+  # This file is used by applications to exchange
+  # their Kubernetes service account token for a Google Cloud access token.
+  # --credential-source-file=/var/run/service-account/token: Specifies the path to the
+  #    Kubernetes service account token, which will be exchanged for GCP credentials.
+  gcloud iam workload-identity-pools create-cred-config $WI_POOL_PATH/providers/$GCP_WORKLOAD_IDENTITY_PROVIDER \
+      --credential-source-file=/var/run/service-account/token \
+      --credential-source-type=text \
+      --output-file=credential-configuration.json
+
+
+  # create a configmap with credenital-configuration.json
+  oc create configmap gcp-cred-cm --from-file credential-configuration.json -n $PROVIDER_NAMESPACE
+  rm credential-configuration.json
+
+  # create a secret
+  echo "$SECRET_VALUE" > secret.data
+  echo "SECRET_ID: $SECRET_ID"
+  gcloud secrets create $SECRET_ID --replication-policy=automatic --data-file=secret.data
+  rm secret.data
+
+  sleep 10
+  # give permission to default service account to be able to access the secret
+  gcloud secrets add-iam-policy-binding $SECRET_ID \
+      --member="principal://iam.googleapis.com/$WI_POOL_PATH/subject/system:serviceaccount:default:default" \
+      --role=roles/secretmanager.secretAccessor
+  sleep 20
+}
+
 @test "install gcp provider" {
-  run kubectl apply -f $PROVIDER_YAML --namespace $PROVIDER_NAMESPACE
+
+  curl -s -o $GCP_PROVIDER_YAML $PROVIDER_YAML
+
+  # 1. Add SecurityContext (privileged: true) to the containers within the DaemonSet
+  yq eval " \
+  ($YQ_DAEMONSETS_BASE_PATH \
+  .spec.template.spec.initContainers[] | \
+  select(.name == \"chown-provider-mount\") \
+  ).securityContext = {\"privileged\": true} \
+  " -i "$GCP_PROVIDER_YAML"
+
+  yq eval " \
+  ($YQ_DAEMONSETS_BASE_PATH \
+  .spec.template.spec.containers[] | \
+  select(.name == \"provider\") \
+  ).securityContext = {\"privileged\": true} \
+  " -i "$GCP_PROVIDER_YAML"
+
+
+  # 2. Add Environment Variables to the 'provider' container within the DaemonSet
+  yq eval " \
+  ($YQ_DAEMONSETS_BASE_PATH \
+  .spec.template.spec.containers[] | \
+  select(.name == \"provider\") \
+  ).env += [ \
+    {\"name\": \"GOOGLE_APPLICATION_CREDENTIALS\", \"value\": \"/etc/workload-identity/credential-configuration.json\"}, \
+    {\"name\": \"GAIA_TOKEN_EXCHANGE_ENDPOINT\", \"value\": \"https://sts.googleapis.com/v1/token\"} \
+  ] \
+  " -i "$GCP_PROVIDER_YAML"
+
+  # 3. Add VolumeMounts to the 'provider' container within the DaemonSet
+  yq eval " \
+  ($YQ_DAEMONSETS_BASE_PATH \
+  .spec.template.spec.containers[] | \
+  select(.name == \"provider\") \
+  ).volumeMounts += [ \
+    {\"name\": \"token\", \"mountPath\": \"/var/run/service-account\", \"readOnly\": true}, \
+    {\"name\": \"workload-identity-credential-configuration\", \"mountPath\": \"/etc/workload-identity\", \"readOnly\": true} \
+  ] \
+  " -i "$GCP_PROVIDER_YAML"
+
+  # 4. Add Volumes to the DaemonSet's pod spec
+  yq eval " \
+  ($YQ_DAEMONSETS_BASE_PATH \
+  .spec.template.spec \
+  ).volumes += [ \
+    {\"name\": \"token\", \"projected\": {\"sources\": [{\"serviceAccountToken\": {\"audience\": \"\", \"expirationSeconds\": 3600, \"path\": \"token\"}}]}}, \
+    {\"name\": \"workload-identity-credential-configuration\", \"configMap\": {\"name\": \"gcp-cred-cm\"}} \
+  ] \
+  " -i "$GCP_PROVIDER_YAML"
+
+  run kubectl apply -f $GCP_PROVIDER_YAML
   assert_success
+  oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-gcp -n $PROVIDER_NAMESPACE
 
   kubectl wait --for=condition=Ready --timeout=120s pod -l app=csi-secrets-store-provider-gcp --namespace $PROVIDER_NAMESPACE
 
@@ -52,7 +174,7 @@ export FILE_NAME=${FILE_NAME:-"secret"}
   echo -n "secret-b" | gcloud secrets versions add ${SECRET_ID} --data-file=-
 
   # wait for secret rotation
-  sleep 30
+  sleep 180
   archive_info
   result=$(kubectl exec secrets-store-inline-crd --namespace=$NAMESPACE -- cat /mnt/secrets-store/$FILE_NAME)
   [[ "${result//$'\r'}" == "secret-b" ]]
@@ -82,6 +204,24 @@ export FILE_NAME=${FILE_NAME:-"secret"}
 }
 
 teardown_file() {
+  # delete configmap
+  oc delete cm gcp-cred-cm -n $PROVIDER_NAMESPACE
+  
+  # delete secret
+  gcloud secrets delete $SECRET_ID --quiet
+
+  # delete workload identity pool and provider
+  gcloud iam workload-identity-pools providers delete $GCP_WORKLOAD_IDENTITY_PROVIDER \
+    --workload-identity-pool=$GCP_WORKLOAD_IDENTITY_POOL \
+    --location=$LOCATION \
+    --project=$GCP_PROJECT_ID \
+    --quiet
+
+  gcloud iam workload-identity-pools delete $GCP_WORKLOAD_IDENTITY_POOL \
+    --location=$LOCATIONl \
+    --project=$GCP_PROJECT_ID \
+    --quiet
+
   archive_provider "app=csi-secrets-store-provider-gcp" || true
   archive_info || true
 }

--- a/test/bats/tests/gcp/gcp_v1_secretproviderclass.yaml
+++ b/test/bats/tests/gcp/gcp_v1_secretproviderclass.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   provider: gcp
   parameters:
-    auth: provider-adc
+    # This parameter (auth: provider-adc) is commented out because it represents an alternative
+    # authentication method, instead, we rely on Workload Identity, which leverages
+    # Kubernetes service account tokens for authentication with GCP Secret Manager, providing
+    # more granular and secure access control per application pod.
+    #auth: provider-adc
     secrets: |
       - resourceName: $RESOURCE_NAME
         fileName: $FILE_NAME


### PR DESCRIPTION
**Description of the change:**
This PR addresses https://issues.redhat.com/browse/SSCSI-145 
- refactors the upstream gcp.bats tests, enabling them to run successfully as a pre-submit job in prow CI environment.
- It makes use of and sets up, Workload Identity federation to authenticate workload pod to use google cloud resources, in this case- secrets. 
- It uses static YAML to install GCP Provider.
- It adds the necessary privileged SCC to GCP provider.

**Motivation for the change:**
Make upstream GCP e2e tests compatible to run on downstream infra.