### PR TITLE
SSCSI-174: UPSTREAM: <carry>: Make aws e2e tests more reliable

### DIFF
--- a/test/bats/aws.bats
+++ b/test/bats/aws.bats
@@ -178,7 +178,8 @@ teardown_file() {
    [[ "${result//$'\r'}" == "BeforeRotation" ]]
 
    aws ssm put-parameter --name $PM_ROTATION_TEST_NAME --value AfterRotation --type SecureString --overwrite --region $REGION
-   sleep 40
+   # SSCSI Operator has set "--rotation-poll-interval=2m" while deploying the operand.
+   sleep 120
    result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/$PM_ROTATION_TEST_NAME)
    [[ "${result//$'\r'}" == "AfterRotation" ]]
 }
@@ -188,7 +189,8 @@ teardown_file() {
    [[ "${result//$'\r'}" == "BeforeRotation" ]]
   
    aws secretsmanager put-secret-value --secret-id $SM_ROT_TEST_NAME --secret-string AfterRotation --region $REGION
-   sleep 40
+  # SSCSI Operator has set "--rotation-poll-interval=2m" while deploying the operand.
+   sleep 120
    result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/$SM_ROT_TEST_NAME)
    [[ "${result//$'\r'}" == "AfterRotation" ]]
 }


### PR DESCRIPTION
- Follow up: https://github.com/openshift/secrets-store-csi-driver/pull/40

As SSCSI Operator has set `"--rotation-poll-interval=2m"` while deploying the operand, we need to wait until the time has elapsed for the secrets to be rotated correctly. 

- xref: https://github.com/openshift/secrets-store-csi-driver-operator/blob/a4fc5c372303229f3a1ff902a904fd380cfe5f7c/assets/node.yaml#L46

Example failures: https://prow.ci.openshift.org/pr-history/?org=openshift&repo=secrets-store-csi-driver-operator&pr=85

/cc @mytreya-rh 
