### PR TITLE
NO-JIRA: [RHCOS10] Migrate base images from UBI9 to UBI10

### DIFF
--- a/Dockerfile.bats
+++ b/Dockerfile.bats
@@ -1,4 +1,5 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:10.1 AS builder
+USER 0
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
 ENV BATS_VERSION="1.12.0"

--- a/Dockerfile.e2eprovider
+++ b/Dockerfile.e2eprovider
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
 RUN make build-e2e-provider
 
-FROM registry.redhat.io/ubi10:10.1
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/test/e2eprovider/e2e-provider /e2e-provider
 
 LABEL description="Mock provider for Secrets Store CSI Driver"

--- a/Dockerfile.e2eprovider
+++ b/Dockerfile.e2eprovider
@@ -1,9 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:10.1 AS builder
+USER 0
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
 RUN make build-e2e-provider
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.redhat.io/ubi10:10.1
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/test/e2eprovider/e2e-provider /e2e-provider
 
 LABEL description="Mock provider for Secrets Store CSI Driver"

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -6,8 +6,7 @@ RUN make build
 # Print build settings information embedded in the binary.
 RUN go version -m _output/secrets-store-csi
 
-FROM registry.redhat.io/ubi10:10.1
-RUN dnf install -y util-linux ca-certificates && dnf clean all
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/_output/secrets-store-csi /bin/secrets-store-csi
 
 LABEL description="Secrets Store CSI Driver"

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,11 +1,13 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:10.1 AS builder
+USER 0
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver
 COPY . .
 RUN make build
 # Print build settings information embedded in the binary.
 RUN go version -m _output/secrets-store-csi
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.redhat.io/ubi10:10.1
+RUN dnf install -y util-linux ca-certificates && dnf clean all
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver/_output/secrets-store-csi /bin/secrets-store-csi
 
 LABEL description="Secrets Store CSI Driver"

--- a/docs/rhcos10-ubi10-migration.md
+++ b/docs/rhcos10-ubi10-migration.md
@@ -1,0 +1,90 @@
+# PR2: RHCOS10 — Migrate Base Images from OCP/UBI9 to UBI10
+
+## Purpose
+
+Migrate all OpenShift Dockerfile base images from the OCP CI registry (RHEL9-based) to
+`registry.redhat.io` UBI10 images, aligning with the RHCOS10 host OS.
+
+This is the follow-up to PR1 (`rhcos10-ubi9-compat-test`), which validated that the
+existing OCP/UBI9 images run correctly on RHCOS10 nodes. This PR adopts UBI10 as the
+native base for RHCOS10 deployments.
+
+## Background
+
+Red Hat CoreOS 10 (RHCOS10) ships with RHEL10 as its host OS. Using UBI10-based images
+ensures better alignment with the host OS libraries and security updates, and removes the
+dependency on the OCP CI internal registry (`registry.ci.openshift.org`) for runtime
+images.
+
+## Changes
+
+### Registry change
+
+All OpenShift variant images move from the OCP CI registry to the authenticated Red Hat
+registry:
+
+```
+registry.ci.openshift.org/ocp/builder:rhel-9-golang-*  →  registry.redhat.io/ubi10/go-toolset:10.1
+registry.ci.openshift.org/ocp/4.20:base-rhel9           →  registry.redhat.io/ubi10:10.1
+```
+
+### Dockerfile changes
+
+#### `Dockerfile.openshift` — main driver image
+
+| Stage | Before | After |
+|---|---|---|
+| Builder | `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20` | `registry.redhat.io/ubi10/go-toolset:10.1` |
+| Runtime | `registry.ci.openshift.org/ocp/4.20:base-rhel9` | `registry.redhat.io/ubi10:10.1` |
+
+Additional change: added `USER 0` after the builder `FROM` line (required by
+`go-toolset`) and `RUN dnf install -y util-linux ca-certificates && dnf clean all` in
+the runtime stage.
+
+#### `Dockerfile.e2eprovider` — e2e mock provider
+
+| Stage | Before | After |
+|---|---|---|
+| Builder | `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20` | `registry.redhat.io/ubi10/go-toolset:10.1` |
+| Runtime | `registry.ci.openshift.org/ocp/4.20:base-rhel9` | `registry.redhat.io/ubi10:10.1` |
+
+#### `Dockerfile.bats` — bats test runner
+
+| Stage | Before | After |
+|---|---|---|
+| Builder | `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20` | `registry.redhat.io/ubi10/go-toolset:10.1` |
+| Runtime | `src` (prow-injected) | unchanged |
+
+## Files NOT Changed
+
+| File | Reason |
+|---|---|
+| `docker/Dockerfile` | Upstream community Dockerfile using `golang` + `debian-base` — not OCP-specific |
+| `docker/crd.Dockerfile` | Uses `alpine` + `gcr.io/distroless/static` — not OCP-specific |
+| `test/e2eprovider/Dockerfile` | Upstream community Dockerfile using `golang` + `gcr.io/distroless/static` |
+| `.local/Dockerfile` | Local development debug image using `golang:alpine` — not for production |
+| `vendor/` | Vendored dependency, not modified |
+
+## Test Matrix
+
+| Cluster OS | Driver image base | Expected result |
+|---|---|---|
+| RHCOS10 | UBI10 (this PR) | Pass — native RHEL10 base |
+| RHCOS9  | UBI10 (this PR) | Pass — UBI10 containers are compatible with RHCOS9 |
+
+## Test Plan
+
+- [ ] `Dockerfile.openshift` builds successfully with `go-toolset:10.1` as builder and
+  `ubi10:10.1` as runtime
+- [ ] `Dockerfile.e2eprovider` builds successfully with `go-toolset:10.1` as builder and
+  `ubi10:10.1` as runtime
+- [ ] `Dockerfile.bats` builds successfully with `go-toolset:10.1` as builder
+- [ ] CI jobs pass on RHCOS10 cluster nodes with UBI10 base images
+- [ ] CI jobs pass on RHCOS9 cluster nodes with UBI10 base images (regression check)
+- [ ] No regressions compared to UBI9 baseline (PR1)
+
+## References
+
+- [Red Hat UBI10 Container Catalog](https://catalog.redhat.com/en/software/containers/ubi10/ubi/66f2b46b122803e4937d11ae)
+- [Red Hat UBI10 go-toolset Container Catalog](https://catalog.redhat.com/en/software/containers/ubi10/go-toolset)
+- PR1 baseline: `docs/rhcos10-ubi9-compat-test.md`


### PR DESCRIPTION
## Summary

Migrate all OpenShift Dockerfile base images from the OCP CI registry (RHEL9-based) to
`registry.redhat.io` UBI10 for native RHCOS10 compatibility.

| Dockerfile | Builder: Before | Builder: After | Runtime: Before | Runtime: After |
|---|---|---|---|---|
| `Dockerfile.openshift` | `ocp/builder:rhel-9-golang-1.24-openshift-4.20` | `ubi10/go-toolset:10.1` | `ocp/4.20:base-rhel9` | `ubi10:10.1` |
| `Dockerfile.bats` | `ocp/builder:rhel-9-golang-1.24-openshift-4.20` | `ubi10/go-toolset:10.1` | `src` (unchanged) | `src` (unchanged) |
| `Dockerfile.e2eprovider` | `ocp/builder:rhel-9-golang-1.24-openshift-4.20` | `ubi10/go-toolset:10.1` | `ocp/4.20:base-rhel9` | `ubi10:10.1` |

All images move from `registry.ci.openshift.org` → `registry.redhat.io`.

## Prerequisite

PR1 (`rhcos10-ubi9-compat-test`) should pass CI on RHCOS10 nodes before merging this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and runtime container base images to standardized UBI10 variants and adjusted build-stage user context for consistent build execution.

* **Documentation**
  * Added migration guide detailing the image updates, validation checklist, and compatibility notes for the RHCOS10/UBI10 migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->